### PR TITLE
レビュー投稿の不具合を修正

### DIFF
--- a/app/src/main/java/com/example/twieasy/FlickFragment.kt
+++ b/app/src/main/java/com/example/twieasy/FlickFragment.kt
@@ -181,7 +181,7 @@ class FlickFragment : Fragment() {
         private fun showToast(msg: String) = Toast.makeText(
             context,
             msg,
-            Toast.LENGTH_LONG
+            Toast.LENGTH_SHORT
         ).show()
     }
 

--- a/app/src/main/java/com/example/twieasy/MainFragment.kt
+++ b/app/src/main/java/com/example/twieasy/MainFragment.kt
@@ -24,6 +24,7 @@ class MainFragment : Fragment(),MailSender.OnMailSendListener {
     //lateinit var binding:FragmentMainBinding
     lateinit var subjectView : SubjectViewModel
 
+    var counter: Int = 0
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
@@ -95,7 +96,7 @@ class MainFragment : Fragment(),MailSender.OnMailSendListener {
                     title,
                     "開講日時　" + timetable + "\n授業形態 " + styleHeading + "\n" + eval + "\n単位数 " + credit,
                     (r.nextInt() % 100 + 100) % 100,
-                    subjectView.reviewList[7]
+                    subjectView.reviewList[counter++]
                 );
             } catch (ex: Exception) {
                 Log.d("Exception", ex.toString())

--- a/app/src/main/java/com/example/twieasy/PostFragment.kt
+++ b/app/src/main/java/com/example/twieasy/PostFragment.kt
@@ -36,12 +36,12 @@ class PostFragment : Fragment() {
         subjectView = ViewModelProvider(this).get(SubjectViewModel::class.java)
 
         vii.postButton.setOnClickListener {
-            post(ID!!)
+            post()
         }
         return vii
     }
 
-    private fun post(id: Int) {
+    private fun post() {
         val postContent: TextView = vii.findViewById(R.id.reviewContent)
         val postStr: String = postContent.text.toString()
         subjectView.reviewList[ID!! - 1].add(postStr)

--- a/app/src/main/java/com/example/twieasy/ReviewFragment.kt
+++ b/app/src/main/java/com/example/twieasy/ReviewFragment.kt
@@ -55,7 +55,7 @@ class ReviewFragment : Fragment() {
             subjectView.subjects[ID!! - 1].info,
             subjectView.subjects[ID!! - 1].easiness
         )
-        for (i in subjectView.subjects[ID!! - 1].reviews) {//i = sizeも処理される
+        for (i in subjectView.subjects[ID!! - 1].reviews) {
             val r: TextView = TextView(context)
             r.text = i
             r.height = 200

--- a/app/src/main/java/com/example/twieasy/SubjectViewModel.kt
+++ b/app/src/main/java/com/example/twieasy/SubjectViewModel.kt
@@ -10,86 +10,56 @@ data class Subject(
 )//構造体みたいなクラス
 
 
-private var reviews1: MutableCollection<String> = mutableListOf(
-    "楽単!",
-    "落単!",
-    "普通!",
-    "Easy!",
-    "楽単!",
-    "落単!",
-    "楽単!",
-    "落単!",
-    "普通!",
-    "Easy!",
-    "楽単!",
-    "落単!",
-    "楽単!",
-    "落単!",
-    "普通!",
-    "Easy!",
-    "楽単!",
-    "落単!",
-    "楽単!",
-    "落単!",
-    "普通!",
-    "Easy!",
-    "楽単!",
-    "落単!",
-    "楽単!",
-    "落単!",
-    "普通!",
-    "Easy!",
-    "楽単!",
-    "落単!",
-    "楽単!",
-    "落単!",
-    "普通!",
-    "Easy!",
-    "楽単!",
-    "落単!"
+private var reviews0: MutableCollection<String> = mutableListOf(
+    "楽単!", "落単!", "普通!", "Easy!", "楽単!", "落単!", "楽単!", "落単!", "普通!", "Easy!", "楽単!", "落単!",
+    "楽単!", "落単!", "普通!", "Easy!", "楽単!", "落単!", "楽単!", "落単!", "普通!", "Easy!", "楽単!", "落単!"
 )
-private var reviews2: MutableCollection<String> = mutableListOf(
-    "楽単!(人工知能)",
-    "落単!(人工知能)",
-    "普通!(人工知能)",
-    "Easy!(人工知能)"
-)
-private var reviews3: MutableCollection<String> = mutableListOf(
-    "楽単!(人工知能)",
-    "落単!(人工知能)",
-    "普通!(人工知能)",
-    "Easy!(人工知能)"
-)
-private var reviews4: MutableCollection<String> = mutableListOf(
-    "楽単!(人工知能)",
-    "落単!(人工知能)",
-    "普通!(人工知能)",
-    "Easy!(人工知能)"
-)
-private var reviews5: MutableCollection<String> = mutableListOf(
-    "楽単!(人工知能)",
-    "落単!(人工知能)",
-    "普通!(人工知能)",
-    "Easy!(人工知能)"
-)
-private var reviews6: MutableCollection<String> = mutableListOf(
-    "楽単!(人工知能)",
-    "落単!(人工知能)",
-    "普通!(人工知能)",
-    "Easy!(人工知能)"
-)
-private var reviews7: MutableCollection<String> = mutableListOf(
-    "楽単!(人工知能)",
-    "落単!(人工知能)",
-    "普通!(人工知能)",
-    "Easy!(人工知能)"
-)
-private var reviews8: MutableCollection<String> = mutableListOf(
-    "楽単!(人工知能)",
-    "落単!(人工知能)",
-    "普通!(人工知能)",
-    "Easy!(人工知能)"
-)
+private var reviews1: MutableCollection<String> = mutableListOf("楽単!", "落単!", "普通!", "Easy!")
+private var reviews2: MutableCollection<String> = mutableListOf("楽単!", "落単!", "普通!", "Easy!")
+private var reviews3: MutableCollection<String> = mutableListOf("楽単!", "落単!", "普通!", "Easy!")
+private var reviews4: MutableCollection<String> = mutableListOf("楽単!", "落単!", "普通!", "Easy!")
+private var reviews5: MutableCollection<String> = mutableListOf("楽単!", "落単!", "普通!", "Easy!")
+private var reviews6: MutableCollection<String> = mutableListOf("楽単!", "落単!", "普通!", "Easy!")
+private var reviews7: MutableCollection<String> = mutableListOf("楽単!", "落単!", "普通!", "Easy!")
+private var reviews8: MutableCollection<String> = mutableListOf("楽単!", "落単!", "普通!", "Easy!")
+private var reviews9: MutableCollection<String> = mutableListOf("楽単!", "落単!", "普通!", "Easy!")
+private var reviews10: MutableCollection<String> = mutableListOf("楽単!", "落単!", "普通!", "Easy!")
+private var reviews11: MutableCollection<String> = mutableListOf("楽単!", "落単!", "普通!", "Easy!")
+private var reviews12: MutableCollection<String> = mutableListOf("楽単!", "落単!", "普通!", "Easy!")
+private var reviews13: MutableCollection<String> = mutableListOf("楽単!", "落単!", "普通!", "Easy!")
+private var reviews14: MutableCollection<String> = mutableListOf("楽単!", "落単!", "普通!", "Easy!")
+private var reviews15: MutableCollection<String> = mutableListOf("楽単!", "落単!", "普通!", "Easy!")
+private var reviews16: MutableCollection<String> = mutableListOf("楽単!", "落単!", "普通!", "Easy!")
+private var reviews17: MutableCollection<String> = mutableListOf("楽単!", "落単!", "普通!", "Easy!")
+private var reviews18: MutableCollection<String> = mutableListOf("楽単!", "落単!", "普通!", "Easy!")
+private var reviews19: MutableCollection<String> = mutableListOf("楽単!", "落単!", "普通!", "Easy!")
+private var reviews20: MutableCollection<String> = mutableListOf("楽単!", "落単!", "普通!", "Easy!")
+private var reviews21: MutableCollection<String> = mutableListOf("楽単!", "落単!", "普通!", "Easy!")
+private var reviews22: MutableCollection<String> = mutableListOf("楽単!", "落単!", "普通!", "Easy!")
+private var reviews23: MutableCollection<String> = mutableListOf("楽単!", "落単!", "普通!", "Easy!")
+private var reviews24: MutableCollection<String> = mutableListOf("楽単!", "落単!", "普通!", "Easy!")
+private var reviews25: MutableCollection<String> = mutableListOf("楽単!", "落単!", "普通!", "Easy!")
+private var reviews26: MutableCollection<String> = mutableListOf("楽単!", "落単!", "普通!", "Easy!")
+private var reviews27: MutableCollection<String> = mutableListOf("楽単!", "落単!", "普通!", "Easy!")
+private var reviews28: MutableCollection<String> = mutableListOf("楽単!", "落単!", "普通!", "Easy!")
+private var reviews29: MutableCollection<String> = mutableListOf("楽単!", "落単!", "普通!", "Easy!")
+private var reviews30: MutableCollection<String> = mutableListOf("楽単!", "落単!", "普通!", "Easy!")
+private var reviews31: MutableCollection<String> = mutableListOf("楽単!", "落単!", "普通!", "Easy!")
+private var reviews32: MutableCollection<String> = mutableListOf("楽単!", "落単!", "普通!", "Easy!")
+private var reviews33: MutableCollection<String> = mutableListOf("楽単!", "落単!", "普通!", "Easy!")
+private var reviews34: MutableCollection<String> = mutableListOf("楽単!", "落単!", "普通!", "Easy!")
+private var reviews35: MutableCollection<String> = mutableListOf("楽単!", "落単!", "普通!", "Easy!")
+private var reviews36: MutableCollection<String> = mutableListOf("楽単!", "落単!", "普通!", "Easy!")
+private var reviews37: MutableCollection<String> = mutableListOf("楽単!", "落単!", "普通!", "Easy!")
+private var reviews38: MutableCollection<String> = mutableListOf("楽単!", "落単!", "普通!", "Easy!")
+private var reviews39: MutableCollection<String> = mutableListOf("楽単!", "落単!", "普通!", "Easy!")
+private var reviews40: MutableCollection<String> = mutableListOf("楽単!", "落単!", "普通!", "Easy!")
+private var reviews41: MutableCollection<String> = mutableListOf("楽単!", "落単!", "普通!", "Easy!")
+private var reviews42: MutableCollection<String> = mutableListOf("楽単!", "落単!", "普通!", "Easy!")
+private var reviews43: MutableCollection<String> = mutableListOf("楽単!", "落単!", "普通!", "Easy!")
+private var reviews44: MutableCollection<String> = mutableListOf("楽単!", "落単!", "普通!", "Easy!")
+private var reviews45: MutableCollection<String> = mutableListOf("楽単!", "落単!", "普通!", "Easy!")
+private var reviews46: MutableCollection<String> = mutableListOf("楽単!", "落単!", "普通!", "Easy!")
 
 
 class SubjectViewModel: ViewModel() {
@@ -97,14 +67,11 @@ class SubjectViewModel: ViewModel() {
     var loaded: Boolean = false
 
     var reviewList = mutableListOf(
-        reviews1,
-        reviews2,
-        reviews3,
-        reviews4,
-        reviews5,
-        reviews6,
-        reviews7,
-        reviews8
+        reviews0, reviews1, reviews2, reviews3, reviews4, reviews5, reviews6, reviews7, reviews8, reviews9,
+        reviews10, reviews11, reviews12, reviews13, reviews14, reviews15, reviews16, reviews17, reviews18, reviews19,
+        reviews20, reviews21, reviews22, reviews23, reviews24, reviews25, reviews26, reviews27, reviews28, reviews29,
+        reviews30, reviews31, reviews32, reviews33, reviews34, reviews35, reviews36, reviews37, reviews38, reviews39,
+        reviews40, reviews41, reviews42, reviews43, reviews44, reviews45, reviews46
     )
 
     var subjectsInfo =  mutableListOf(


### PR DESCRIPTION
レビューの投稿が反映されなかった不具合を修正した。
[具体的な不具合]
・上から7つ目までの科目のレビューは反映されない。(レビューを追加した配列を使用していなかったため。)
・上から8つ目の科目のレビューはすべての科目に反映される。(同じ一つのレビュー配列をすべての科目で表示していたため。)
・上から9つ目以降の科目はレビューすると落ちる。(存在しない配列にレビューを追加しようとしていたため。)

[変更点]
・レビューの配列を47個(科目の個数)にしてSubjectViewModel.kt内の配列reviewListに追加した。
・Mainfragment.kt内99行目で講義ごとに固有のレビュー配列を渡すこととした。
・PostFragment.kt内の関数postの使われていなかった引数の削除
・スワイプ時のtoastの継続時間の短縮